### PR TITLE
Geminiの宛先変更

### DIFF
--- a/backend/services/geminiService.js
+++ b/backend/services/geminiService.js
@@ -6,7 +6,7 @@ const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 /**
  * Gemini APIクライアントを初期化します。
  */
-const GEMINI_MODEL_NAME = 'gemini-1.5-flash-latest'; // 追加
+const GEMINI_MODEL_NAME = 'gemini-2.5-flash'; // 追加
 
 function initializeGemini() {
     if (GEMINI_API_KEY) {


### PR DESCRIPTION
Google AIの公式ドキュメントで推奨されているモデル名 `gemini-2.5-flash` に更新しました。 これにより、モデルが見つからないために発生していた `404 Not Found` エラーが解決されます。